### PR TITLE
add !#[feature(let_chains) to places where the feature is used

### DIFF
--- a/supervision/src/main.rs
+++ b/supervision/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(async_closure)]
+#![feature(let_chains)]
 
 pub mod exec_script;
 pub mod kill_process;

--- a/svc/src/main.rs
+++ b/svc/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(async_closure)]
+#![feature(let_chains)]
 
 pub mod live_service;
 pub mod live_service_graph;


### PR DESCRIPTION
This allows earlier versions on the nightly channel to work. Currently you would need 1.64.0 on the nightly channel while with this you could get by with 1.60.0 on the nightly channel.