### PR TITLE
Do not depend on let_chains feature

### DIFF
--- a/supervision/src/log_stdio.rs
+++ b/supervision/src/log_stdio.rs
@@ -37,7 +37,7 @@ pub fn log_buf(
     let mut last_newline = 0;
     // If there is output remaining from the latest read call
     // and there is a newline in buf
-    if !previous_line.is_empty() && let Some(index) = buf.find('\n') {
+    if let Some(index) = buf.find('\n').filter(|_| !previous_line.is_empty()) {
                     // print the resulting line
                     info!("[{stdio}] {previous_line}{}", &buf[..index]);
                     previous_line.clear();
@@ -46,7 +46,7 @@ pub fn log_buf(
 
     // iterate all other lines and stop when either the newline found
     // was the last character or the there are no more newlines
-    while last_newline != buf.len() && let Some(index) = buf[last_newline..].find('\n') {
+    while let Some(index) = buf.get(last_newline..).and_then(|b| b.find('\n')) {
                     // the index returned from find refers to new &str buf[last_newline..]
                     // so we need to port it back for buf, by adding last_new_line to it
                     let index = last_newline + index;

--- a/supervision/src/supervise_long_lived_process.rs
+++ b/supervision/src/supervise_long_lived_process.rs
@@ -189,7 +189,7 @@ pub async fn supervise_long_lived_process(service: Service) -> Result<()> {
             running_script.logger_stop.send(()).unwrap();
         }
         running_script.logger.await??;
-        if let Some(res) = res && matches!(res, ScriptResult::SignalReceived) {
+        if let Some(ScriptResult::SignalReceived) = res {
             break;
         }
     }

--- a/svc/src/live_service_graph.rs
+++ b/svc/src/live_service_graph.rs
@@ -369,18 +369,17 @@ impl LiveServiceGraph {
                             for dependent in dependents {
                                 // Wait until the dependent is down
                                 // TODO: Log
-                                while let Ok(state) = dependent.tx.subscribe().recv().await &&
-                                    state == IdleServiceState::Up { }
+                                while let Ok(IdleServiceState::Up) = dependent.tx.subscribe().recv().await {
+                                }
                             }
                             self.stop_service_impl(live_service).await.unwrap();
 
                             // Self::stop_service only spawn the supervisor, we don't know if the
                             // service has stopped yet. Get the state of each one
-                            if *live_service.state.borrow()
-                                == ServiceState::Idle(IdleServiceState::Up)
-                                && let Ok(state) = live_service.tx.subscribe().recv().await &&
-                                    state == IdleServiceState::Up {
+                            if *live_service.state.borrow() == ServiceState::Idle(IdleServiceState::Up) {
+                                if let Ok(IdleServiceState::Up) = live_service.tx.subscribe().recv().await {
                                         warn!("service {service} didn't exit successfully");
+                                }
                             }
                         }
                     });


### PR DESCRIPTION
At the moment, building rinit fails because of a missing `#![feature(let_chains)]` statement. Instead of adding a dependency on this nightly feature, rewrite the code that needs this feature so that it does not.