### PR TITLE
Fix cargo fmt warnings

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,6 @@
 combine_control_expr = false
 condense_wildcard_suffixes = true
-fn_args_layout = "Vertical"
+fn_params_layout = "Vertical"
 force_multiline_blocks = true
 format_strings = true
 imports_layout = "Vertical"

--- a/supervision/src/log_stdio.rs
+++ b/supervision/src/log_stdio.rs
@@ -38,22 +38,22 @@ pub fn log_buf(
     // If there is output remaining from the latest read call
     // and there is a newline in buf
     if let Some(index) = buf.find('\n').filter(|_| !previous_line.is_empty()) {
-                    // print the resulting line
-                    info!("[{stdio}] {previous_line}{}", &buf[..index]);
-                    previous_line.clear();
-                    last_newline = index + 1;
-                }
+        // print the resulting line
+        info!("[{stdio}] {previous_line}{}", &buf[..index]);
+        previous_line.clear();
+        last_newline = index + 1;
+    }
 
     // iterate all other lines and stop when either the newline found
     // was the last character or the there are no more newlines
     while let Some(index) = buf.get(last_newline..).and_then(|b| b.find('\n')) {
-                    // the index returned from find refers to new &str buf[last_newline..]
-                    // so we need to port it back for buf, by adding last_new_line to it
-                    let index = last_newline + index;
-                    // print every line
-                    info!("[{stdio}] {}", &buf[last_newline..index]);
-                    last_newline = index + 1;
-                }
+        // the index returned from find refers to new &str buf[last_newline..]
+        // so we need to port it back for buf, by adding last_new_line to it
+        let index = last_newline + index;
+        // print every line
+        info!("[{stdio}] {}", &buf[last_newline..index]);
+        last_newline = index + 1;
+    }
 
     // if there are characters after the last newline, store them
     // so that they can be print in the next loop

--- a/svc/src/live_service_graph.rs
+++ b/svc/src/live_service_graph.rs
@@ -369,16 +369,22 @@ impl LiveServiceGraph {
                             for dependent in dependents {
                                 // Wait until the dependent is down
                                 // TODO: Log
-                                while let Ok(IdleServiceState::Up) = dependent.tx.subscribe().recv().await {
+                                while let Ok(IdleServiceState::Up) =
+                                    dependent.tx.subscribe().recv().await
+                                {
                                 }
                             }
                             self.stop_service_impl(live_service).await.unwrap();
 
                             // Self::stop_service only spawn the supervisor, we don't know if the
                             // service has stopped yet. Get the state of each one
-                            if *live_service.state.borrow() == ServiceState::Idle(IdleServiceState::Up) {
-                                if let Ok(IdleServiceState::Up) = live_service.tx.subscribe().recv().await {
-                                        warn!("service {service} didn't exit successfully");
+                            if *live_service.state.borrow()
+                                == ServiceState::Idle(IdleServiceState::Up)
+                            {
+                                if let Ok(IdleServiceState::Up) =
+                                    live_service.tx.subscribe().recv().await
+                                {
+                                    warn!("service {service} didn't exit successfully");
                                 }
                             }
                         }


### PR DESCRIPTION
* Update an obsolete option name
* Apply format changes suggested by `cargo fmt`